### PR TITLE
chore: remove test job dependency in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    # Only run this job if the test workflow passes
-    needs: [test]
+    # Removing the dependency on test job for now
+    # needs: [test]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Removes the dependency on the test job in the deploy workflow for now. 
This change allows the deployment to proceed independently of test 
results, facilitating quicker deployments during development.